### PR TITLE
予定削除時に関連情報が全て削除されることのテストを追加

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -268,19 +268,23 @@ describe('/schedules/:scheduleId?delete=1', () => {
               where: { scheduleId: scheduleId }
             }).then((comments) => {
               // TODO テストを実装
+              assert.equal(comments.length, 0);
             });
             const p2 = Availability.findAll({
               where: { scheduleId: scheduleId }
             }).then((availabilities) => {
               // TODO テストを実装
+              assert.equal(availabilities.length, 0);
             });
             const p3 = Candidate.findAll({
               where: { scheduleId: scheduleId }
             }).then((candidates) => {
               // TODO テストを実装
+              assert.equal(candidates.length, 0);
             });
             const p4 = Schedule.findById(scheduleId).then((schedule) => {
               // TODO テストを実装
+              assert.equal(!schedule, true);
             });
             Promise.all([p1, p2, p3, p4]).then(() => {
               if (err) return done(err);


### PR DESCRIPTION
予定削除時に、

- コメント
- 出欠
- 候補
- 予定

が全てDB上から削除されることのテストを実装しました。

---
練習なのでマージ不要です。